### PR TITLE
Fix crash when cache folder is not in the subpath of the test directory

### DIFF
--- a/pytest_insta/session.py
+++ b/pytest_insta/session.py
@@ -98,7 +98,7 @@ class SnapshotSession(Dict[Path, SnapshotContext]):
         record_dir = self.config.cache.makedir("insta")
 
         self.tr = self.config.pluginmanager.getplugin("terminalreporter")
-        self.record_dir = Path(record_dir).relative_to(Path(".").resolve())
+        self.record_dir = Path(os.path.relpath(Path(record_dir), Path(".").resolve()))
         self.strategy = self.config.option.insta
 
         if self.strategy == "auto":


### PR DESCRIPTION
Pythlib cannot handle this case while os.path has no problems.

Example:

```
INTERNALERROR>   File "<string>", line 11, in __init__
INTERNALERROR>   File "/Users/berres/venv/weplan3.9/lib/python3.9/site-packages/pytest_insta/session.py", line 101, in __post_init__
INTERNALERROR>     self.record_dir = Path(record_dir).relative_to(Path(".").resolve())
INTERNALERROR>   File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/pathlib.py", line 928, in relative_to
INTERNALERROR>     raise ValueError("{!r} is not in the subpath of {!r}"
INTERNALERROR> ValueError: '/Users/berres/Devel/mpptool/.pytest_cache/d/insta' is not in the subpath of '/Users/berres/Devel/mpptool/backend/cdb/cdb/tests/flaskapp' OR one path is relative and the other is absolute.

```