### PR TITLE
Use directories for snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # Node
 node_modules/
+
+## IDE: Jetbrains
+
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!--next-version-placeholder-->
 
+## v0.4.0 (2024-07-12)
+
+### Feature
+
+* Added use_directories_for_snapshots ([`06a0cc5`](https://github.com/vberlier/pytest-insta/commit/06a0cc55269a8447a495ddad8e25cb703cb9fe13))
+
+
 ## v0.3.0 (2024-02-19)
 
 ### Feature

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-insta"
-version = "0.3.0"
+version = "0.4.0"
 description = "A practical snapshot testing plugin for pytest"
 authors = ["Valentin Berlier <berlier.v@gmail.com>"]
 license = "MIT"

--- a/pytest_insta/__init__.py
+++ b/pytest_insta/__init__.py
@@ -2,4 +2,4 @@ from .fixture import *
 from .format import *
 from .session import *
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/pytest_insta/config.py
+++ b/pytest_insta/config.py
@@ -1,0 +1,16 @@
+__all__ = ["SnapshotConfig"]
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class SnapshotConfig:
+    use_directories_for_snapshots: bool
+
+    @staticmethod
+    def from_node(node: Any) -> "SnapshotConfig":
+        marker = node.get_closest_marker("pytest_insta")
+        if marker is None:
+            return SnapshotConfig(use_directories_for_snapshots=False)
+        return marker.kwargs.get("config")

--- a/pytest_insta/fixture.py
+++ b/pytest_insta/fixture.py
@@ -1,6 +1,5 @@
 __all__ = ["SnapshotFixture", "SnapshotRecorder", "SnapshotNotfound"]
 
-
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -8,9 +7,10 @@ from typing import Any
 from _pytest import fixtures
 from wrapt import ObjectProxy
 
+from .config import SnapshotConfig
 from .format import Fmt
 from .session import SnapshotContext, SnapshotSession
-from .utils import node_path_name
+from .utils import get_snapshots_path
 
 
 @dataclass
@@ -46,8 +46,9 @@ class SnapshotFixture:
 
     @classmethod
     def from_request(cls, request: fixtures.FixtureRequest) -> "SnapshotFixture":
-        path, name = node_path_name(request.node)  # type: ignore
-        path = path.with_name("snapshots") / name
+        node = request.node  # type: ignore
+        config = SnapshotConfig.from_node(node)
+        path = get_snapshots_path(node, config.use_directories_for_snapshots)
         session: SnapshotSession = getattr(request.config, "_snapshot_session")
         return cls(session[path], session)
 

--- a/pytest_insta/mark.py
+++ b/pytest_insta/mark.py
@@ -1,0 +1,15 @@
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from pytest_insta.config import SnapshotConfig
+
+
+def config(
+    config: SnapshotConfig,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        return pytest.mark.pytest_insta(config=config)(func)
+
+    return decorator

--- a/pytest_insta/plugin.py
+++ b/pytest_insta/plugin.py
@@ -1,6 +1,5 @@
 # type: ignore
 
-
 import pytest
 
 from .fixture import SnapshotFixture
@@ -47,3 +46,9 @@ def pytest_sessionfinish(session, exitstatus):
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     config._snapshot_session.write_summary()
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "pytest_insta(config): marker for pytest_insta configuration"
+    )

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.poetry]
+name = "pytest-insta-tests"
+
+pytest_insta = { path = "./../pytest_insta", develop = true }

--- a/tests/snapshots/very_long_file_name/test_use_directories_for_snapshots__0.txt
+++ b/tests/snapshots/very_long_file_name/test_use_directories_for_snapshots__0.txt
@@ -1,0 +1,1 @@
+simple_test

--- a/tests/snapshots/very_long_file_name/test_use_directories_for_snapshots_with_cases/test_case_1__0.txt
+++ b/tests/snapshots/very_long_file_name/test_use_directories_for_snapshots_with_cases/test_case_1__0.txt
@@ -1,0 +1,1 @@
+test_case_1

--- a/tests/snapshots/very_long_file_name/test_use_directories_for_snapshots_with_cases/test_case_2__0.txt
+++ b/tests/snapshots/very_long_file_name/test_use_directories_for_snapshots_with_cases/test_case_2__0.txt
@@ -1,0 +1,1 @@
+test_case_2

--- a/tests/snapshots/very_long_file_name__not_use_directories_for_snapshots_test_case_1__0.txt
+++ b/tests/snapshots/very_long_file_name__not_use_directories_for_snapshots_test_case_1__0.txt
@@ -1,0 +1,1 @@
+test_case_1

--- a/tests/snapshots/very_long_file_name__not_use_directories_for_snapshots_test_case_2__0.txt
+++ b/tests/snapshots/very_long_file_name__not_use_directories_for_snapshots_test_case_2__0.txt
@@ -1,0 +1,1 @@
+test_case_2

--- a/tests/test_very_long_file_name.py
+++ b/tests/test_very_long_file_name.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+import pytest
+
+import pytest_insta.mark
+from pytest_insta.config import SnapshotConfig
+
+
+@pytest_insta.mark.config(config=SnapshotConfig(use_directories_for_snapshots=True))
+def test_use_directories_for_snapshots(snapshot: Any):
+    assert snapshot(".txt") == "simple_test"
+
+
+@pytest_insta.mark.config(config=SnapshotConfig(use_directories_for_snapshots=True))
+@pytest.mark.parametrize("case", ["test_case_1", "test_case_2"])
+def test_use_directories_for_snapshots_with_cases(snapshot: Any, case: str):
+    assert snapshot(".txt") == case
+
+
+@pytest_insta.mark.config(config=SnapshotConfig(use_directories_for_snapshots=False))
+@pytest.mark.parametrize("case", ["test_case_1", "test_case_2"])
+def test_not_use_directories_for_snapshots(snapshot: Any, case: str):
+    assert snapshot(".txt") == case


### PR DESCRIPTION
Motivation: Snapshot names can be very long, which complicates
navigation in IDEs. use_directories_for_snapshots allows
splitting long test snapshot names into directories, thereby
resolving the navigation issue.