### PR TITLE
feat: customize init method of snapshot

### DIFF
--- a/pytest_insta/fixture.py
+++ b/pytest_insta/fixture.py
@@ -3,12 +3,12 @@ __all__ = ["SnapshotFixture", "SnapshotRecorder", "SnapshotNotfound"]
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from _pytest import fixtures
 from wrapt import ObjectProxy
 
-from .format import Fmt
+from .format import Fmt, LoadParamsSpec
 from .session import SnapshotContext, SnapshotSession
 from .utils import node_path_name
 
@@ -51,7 +51,7 @@ class SnapshotFixture:
         session: SnapshotSession = getattr(request.config, "_snapshot_session")
         return cls(session[path], session)
 
-    def __call__(self, spec: str = ".txt") -> Any:
+    def __call__(self, spec: str = ".txt", fmt_load_params: Optional[LoadParamsSpec] = None) -> Any:
         __tracebackhide__ = True
 
         name, fmt = Fmt.from_spec(spec)
@@ -64,6 +64,8 @@ class SnapshotFixture:
 
         path = self.ctx.path.with_name(f"{self.ctx.path.name}__{name}")
 
+        fmt_load_params = fmt_load_params or LoadParamsSpec([], {})
+        fmt.load_params_spec = fmt_load_params
         current = (
             fmt.load(path) if path in self.ctx.available else SnapshotNotfound(path)
         )

--- a/pytest_insta/format.py
+++ b/pytest_insta/format.py
@@ -1,4 +1,4 @@
-__all__ = ["Fmt", "FmtText", "FmtBinary", "FmtHexdump", "FmtJson", "FmtPickle"]
+__all__ = ["Fmt", "FmtText", "FmtBinary", "FmtHexdump", "FmtJson", "FmtPickle", "LoadParamsSpec"]
 
 
 import json
@@ -6,15 +6,23 @@ import pickle
 from itertools import accumulate
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Generic, Optional, Tuple, Type, TypeVar
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
 
 from .utils import hexdump, hexload
 
 T = TypeVar("T")
 
+@dataclass
+class LoadParamsSpec():
+    args: Sequence[Any] = field(default_factory=list)
+    kwargs: Mapping[str, Any] = field(default_factory=dict)
+
 
 class Fmt(Generic[T]):
     extension: ClassVar[str] = ""
     registry: ClassVar[Dict[str, Type["Fmt[Any]"]]] = {}
+    load_params_spec: Optional[LoadParamsSpec] = None
 
     def __init_subclass__(cls):
         if cls.extension:


### PR DESCRIPTION
This PR implements a way to customize the __init__ method. Not sure if it's the best naming convention though.

This is useful in this PR on the beet repo : https://github.com/mcbeet/beet/pull/446
